### PR TITLE
Documentation Patch, advising that the module uses the v1 API key

### DIFF
--- a/DigitalOcean/lib/DigitalOcean.pm
+++ b/DigitalOcean/lib/DigitalOcean.pm
@@ -137,6 +137,11 @@ This module is an object oriented interface into the Digital Ocean API.
 
     $new_droplet->enable_backups;
 
+=head2 Getting an API Key
+
+This module uses version 1 of the Digital::Ocean API, so you will need to generate an API v1
+key to use it. The access tokens used by new the API will not work.
+
 =head1 HOW THIS MODULE IS WRITTEN
 
 This module is written to be flexible, so that if changes are made to the Digital Ocean API,

--- a/DigitalOcean/lib/DigitalOcean.pm
+++ b/DigitalOcean/lib/DigitalOcean.pm
@@ -137,10 +137,10 @@ This module is an object oriented interface into the Digital Ocean API.
 
     $new_droplet->enable_backups;
 
-=head2 Getting an API Key
+=head2 API Key
 
 This module uses version 1 of the Digital::Ocean API, so you will need to generate an API v1
-key to use it. The access tokens used by new the API will not work.
+key to use it. The access tokens used by the new API will not work.
 
 =head1 HOW THIS MODULE IS WRITTEN
 


### PR DESCRIPTION
I just installed this module and had to spend some time figuring out that it used the old api key. I just added a quick paragraph at the end of the synopsis so new users will be immediately aware of this.