### PR TITLE
Made destroy method work

### DIFF
--- a/DigitalOcean/lib/DigitalOcean/Domain/Record.pm
+++ b/DigitalOcean/lib/DigitalOcean/Domain/Record.pm
@@ -146,7 +146,7 @@ This method deletes the specified domain record.
 =cut
 
 method destroy { 
-	$self->Domain->_request('', $self->id . '/destroy');
+	$self->Domain->_record_request('', $self->id . '/destroy');
 	return 1;
 }
 


### PR DESCRIPTION
Hi,

The destroy method wasn't working for me on a Domain::Record object. This change made it work fine for me.

Perl v5.14.3 which is quite old but I don't think that was causing the issue.

Thanks also for taking the time to write and release this module.

Allan